### PR TITLE
ci: reduce complexity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,15 +3,15 @@ on:
   push:
     branches:
       - main
-  pull_request:
 permissions:
   contents: write
   id-token: write
   attestations: write
 
-
 jobs:
   semantic-release:
+    # Only perform semantic-release on main
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     # TODO
     # needs: test
@@ -22,17 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
-      - name: Semantic Release (dry run on PR)
-        if: github.event_name == 'pull_request'
-        uses: go-semantic-release/action@v1
-        with:
-          dry: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Semantic Release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: go-semantic-release/action@v1
+      - uses: go-semantic-release/action@v1
         with:
           hooks: goreleaser
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: CI/CD
 on:
   push:
-    tags:
-      - "v*"
     branches:
       - main
 permissions:
@@ -11,19 +9,8 @@ permissions:
   attestations: write
 
 jobs:
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cli/gh-extension-precompile@v2
-        with:
-          generate_attestations: true
-          go_version_file: go.mod
-
   semantic-release:
     # Only perform semantic-release on main
-    # The purpose of this is to generate a new version tag based on the commit messages
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     # TODO
@@ -34,7 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 1.24.1
+          hooks: goreleaser
       - uses: go-semantic-release/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
-          hooks: goreleaser
       - uses: go-semantic-release/action@v1
+        with:
+          hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,15 +3,15 @@ on:
   push:
     branches:
       - main
+  pull_request:
 permissions:
   contents: write
   id-token: write
   attestations: write
 
+
 jobs:
   semantic-release:
-    # Only perform semantic-release on main
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     # TODO
     # needs: test
@@ -22,7 +22,17 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
-      - uses: go-semantic-release/action@v1
+      - name: Semantic Release (dry run on PR)
+        if: github.event_name == 'pull_request'
+        uses: go-semantic-release/action@v1
+        with:
+          dry: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Semantic Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: go-semantic-release/action@v1
         with:
           hooks: goreleaser
         env:


### PR DESCRIPTION
We actually don't (in theory) need the `release` job, because this just gently wraps a relatively straightforward 