### PR TITLE
fix: graphql error on legacy gh cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,10 +58,10 @@ func runTemplatePR(action string) func(cmd *cobra.Command, args []string) error 
 			stderrOutput := stderrBuf.String()
 			if strings.Contains(stderrOutput, "GraphQL: Projects (classic) is being deprecated") {
 				return fmt.Errorf(
-					"error running gh pr %s: The `gh` CLI encountered a deprecated GitHub Projects API. " +
-						"This is likely due to an outdated `gh` CLI version. " +
-						"Please update your GitHub CLI to the latest version. " +
-						"Original error: %w", err)
+					"error running gh pr %s: The `gh` CLI encountered a deprecated GitHub Projects API. "+
+						"This is likely due to an outdated `gh` CLI version. "+
+						"Please update your GitHub CLI to the latest version. "+
+						"Original error: %v", action, err)
 			}
 			return fmt.Errorf("error running gh pr %s: %w", action, err)
 		}


### PR DESCRIPTION
# Goal
_Explain the high-level goal of this PR. What problem does it solve, or what functionality does it add?_
Fixes #6 .  

# Summary
This is not actually a bug, but as observed and demonstrated here (a local build generated this PR), the issue is observed when GH is not up to date.  

- the previous version used on my local machine was `gh version 2.72.0 (2025-04-30)`, which presented the error.  
- Upon updating to the latest available `gh version 2.83.1 (2025-11-13)` the issue was resolved.  

It seems worth while to memorialize this issue and catch it when found, notifying users if it is there.  
- This could eventually be refactored such that a minimum `gh` version is set across the whole app.  this might imply more end to end tests in CI, but reasonably speaking when this CLI updates it should assume the latest version of GH.  


# Testing
Conducted herein.  

