### PR TITLE
feat: add update subcommad to refresh local repo cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go test ./...
 
       - name: build

--- a/lib/repo.go
+++ b/lib/repo.go
@@ -51,21 +51,20 @@ func (rc *RepoCache) EnsureCloned() error {
 	return nil
 }
 
-var ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
-	cmd := exec.Command("gh", "repo", "sync", fmt.Sprintf("%s/%s", owner, repoName))
-	cmd.Dir = path // Set the working directory for the command
+var syncCommand = func(owner, repoName, path string) *exec.Cmd {
+	cmd := exec.Command("gh", "repo", "sync", "--source", fmt.Sprintf("%s/%s", owner, repoName))
+	cmd.Dir = path
 	return cmd
 }
 
 // Update pulls the latest changes for the cached repository.
 func (rc *RepoCache) Update() error {
-	// Ensure the repository is cloned before attempting to update
 	if err := rc.EnsureCloned(); err != nil {
 		return fmt.Errorf("failed to ensure repository is cloned before update: %w", err)
 	}
 
 	fmt.Printf("Updating %s/%s in %s...\n", rc.Owner, rc.RepoName, rc.Path)
-	cmd := ghSyncCommand(rc.Owner, rc.RepoName, rc.Path)
+	cmd := syncCommand(rc.Owner, rc.RepoName, rc.Path)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/lib/repo.go
+++ b/lib/repo.go
@@ -51,6 +51,29 @@ func (rc *RepoCache) EnsureCloned() error {
 	return nil
 }
 
+var ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
+	cmd := exec.Command("gh", "repo", "sync", fmt.Sprintf("%s/%s", owner, repoName))
+	cmd.Dir = path // Set the working directory for the command
+	return cmd
+}
+
+// Update pulls the latest changes for the cached repository.
+func (rc *RepoCache) Update() error {
+	// Ensure the repository is cloned before attempting to update
+	if err := rc.EnsureCloned(); err != nil {
+		return fmt.Errorf("failed to ensure repository is cloned before update: %w", err)
+	}
+
+	fmt.Printf("Updating %s/%s in %s...\n", rc.Owner, rc.RepoName, rc.Path)
+	cmd := ghSyncCommand(rc.Owner, rc.RepoName, rc.Path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to update repository %s/%s: %w", rc.Owner, rc.RepoName, err)
+	}
+	return nil
+}
+
 // TemplatePath returns the full path to a template file in the cached repository.
 func (rc *RepoCache) TemplatePath(templateName string) string {
 	templatePath := filepath.Join(rc.Path, "templates", templateName)

--- a/lib/repo_integration_test.go
+++ b/lib/repo_integration_test.go
@@ -1,0 +1,49 @@
+package lib
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureClonedIntegration(t *testing.T) {
+	if os.Getenv("GH_TOKEN") == "" {
+		t.Skip("GH_TOKEN not set, skipping integration test")
+	}
+
+	tmpDir := t.TempDir()
+	rc := &RepoCache{
+		Owner:    "karldreher",
+		RepoName: "gh-qpr",
+		Path:     filepath.Join(tmpDir, "gh-qpr"),
+	}
+
+	if err := rc.EnsureCloned(); err != nil {
+		t.Fatalf("EnsureCloned() failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(rc.Path, ".git")); err != nil {
+		t.Errorf("expected .git directory in cloned repo, got: %v", err)
+	}
+}
+
+func TestUpdateIntegration(t *testing.T) {
+	if os.Getenv("GH_TOKEN") == "" {
+		t.Skip("GH_TOKEN not set, skipping integration test")
+	}
+
+	tmpDir := t.TempDir()
+	rc := &RepoCache{
+		Owner:    "karldreher",
+		RepoName: "gh-qpr",
+		Path:     filepath.Join(tmpDir, "gh-qpr"),
+	}
+
+	if err := rc.EnsureCloned(); err != nil {
+		t.Fatalf("EnsureCloned() setup failed: %v", err)
+	}
+
+	if err := rc.Update(); err != nil {
+		t.Fatalf("Update() failed: %v", err)
+	}
+}

--- a/lib/repo_test.go
+++ b/lib/repo_test.go
@@ -108,11 +108,10 @@ func TestEnsureCloned(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	// Setup: Override ghSyncCommand and cloneCommand to mock git/gh operations
-	oldGhSyncCommand := ghSyncCommand
+	oldSyncCommand := syncCommand
 	oldCloneCommand := cloneCommand
 	defer func() {
-		ghSyncCommand = oldGhSyncCommand
+		syncCommand = oldSyncCommand
 		cloneCommand = oldCloneCommand
 	}()
 
@@ -120,25 +119,21 @@ func TestUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		repoPath := filepath.Join(tmpDir, "gh-qpr-repo")
 
-		// Simulate an already cloned repository by creating the directory
 		if err := os.MkdirAll(repoPath, 0755); err != nil {
 			t.Fatalf("failed to create test repo directory: %v", err)
 		}
 
-		var syncCalled bool // Track if ghSyncCommand was called
-
-		// Mock gh repo sync to succeed
-		ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
+		var syncCalled bool
+		syncCommand = func(owner, repoName, path string) *exec.Cmd {
 			syncCalled = true
 			if path != repoPath {
-				t.Errorf("ghSyncCommand called with unexpected path: got %s, want %s", path, repoPath)
+				t.Errorf("syncCommand called with unexpected path: got %s, want %s", path, repoPath)
 			}
 			return exec.Command("true")
 		}
-		// Mock cloneCommand so it's not called if repo already exists
 		cloneCommand = func(owner, repoName, path string) *exec.Cmd {
 			t.Fatalf("cloneCommand should not be called if repo exists")
-			return exec.Command("false") // Should not be reached
+			return exec.Command("false")
 		}
 
 		rc := &RepoCache{
@@ -151,7 +146,7 @@ func TestUpdate(t *testing.T) {
 			t.Errorf("Update() failed unexpectedly: %v", err)
 		}
 		if !syncCalled {
-			t.Error("ghSyncCommand was not called")
+			t.Error("syncCommand was not called")
 		}
 	})
 
@@ -159,16 +154,13 @@ func TestUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		repoPath := filepath.Join(tmpDir, "gh-qpr-repo-uncloned")
 
-		var cloneCalled bool
-		var syncCalled bool
+		var cloneCalled, syncCalled bool
 
-		// Mock cloneCommand to succeed and mark as called
 		cloneCommand = func(owner, repoName, path string) *exec.Cmd {
 			cloneCalled = true
 			return exec.Command("true")
 		}
-		// Mock ghSyncCommand to succeed and mark as called
-		ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
+		syncCommand = func(owner, repoName, path string) *exec.Cmd {
 			syncCalled = true
 			return exec.Command("true")
 		}
@@ -182,12 +174,11 @@ func TestUpdate(t *testing.T) {
 		if err := rc.Update(); err != nil {
 			t.Fatalf("Update() failed unexpectedly: %v", err)
 		}
-
 		if !cloneCalled {
 			t.Error("cloneCommand was not called when repository did not exist")
 		}
 		if !syncCalled {
-			t.Error("ghSyncCommand was not called after cloning")
+			t.Error("syncCommand was not called after cloning")
 		}
 	})
 
@@ -195,20 +186,17 @@ func TestUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		repoPath := filepath.Join(tmpDir, "gh-qpr-repo-sync-fail")
 
-		// Simulate an already cloned repository
 		if err := os.MkdirAll(repoPath, 0755); err != nil {
 			t.Fatalf("failed to create test repo directory: %v", err)
 		}
 
-		var syncCalled bool // Track if ghSyncCommand was called
-
-		// Mock gh repo sync to fail
-		ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
+		var syncCalled bool
+		syncCommand = func(owner, repoName, path string) *exec.Cmd {
 			syncCalled = true
-			return exec.Command("false") // `false` command exits with non-zero status
+			return exec.Command("false")
 		}
 		cloneCommand = func(owner, repoName, path string) *exec.Cmd {
-			return exec.Command("true") // Ensure cloned always works
+			return exec.Command("true")
 		}
 
 		rc := &RepoCache{
@@ -221,11 +209,11 @@ func TestUpdate(t *testing.T) {
 		if err == nil {
 			t.Error("Update() did not return an error when gh repo sync failed")
 		}
-		if err != nil && !strings.Contains(err.Error(), "failed to update repository") {
+		if !strings.Contains(err.Error(), "failed to update repository") {
 			t.Errorf("unexpected error message: %v", err)
 		}
 		if !syncCalled {
-			t.Error("ghSyncCommand was not called")
+			t.Error("syncCommand was not called")
 		}
 	})
 }

--- a/lib/repo_test.go
+++ b/lib/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -102,6 +103,129 @@ func TestEnsureCloned(t *testing.T) {
 
 		if err := rc.EnsureCloned(); err != nil {
 			t.Fatalf("EnsureCloned() failed: %v", err)
+		}
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	// Setup: Override ghSyncCommand and cloneCommand to mock git/gh operations
+	oldGhSyncCommand := ghSyncCommand
+	oldCloneCommand := cloneCommand
+	defer func() {
+		ghSyncCommand = oldGhSyncCommand
+		cloneCommand = oldCloneCommand
+	}()
+
+	t.Run("updates existing cloned repository successfully", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repoPath := filepath.Join(tmpDir, "gh-qpr-repo")
+
+		// Simulate an already cloned repository by creating the directory
+		if err := os.MkdirAll(repoPath, 0755); err != nil {
+			t.Fatalf("failed to create test repo directory: %v", err)
+		}
+
+		var syncCalled bool // Track if ghSyncCommand was called
+
+		// Mock gh repo sync to succeed
+		ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
+			syncCalled = true
+			if path != repoPath {
+				t.Errorf("ghSyncCommand called with unexpected path: got %s, want %s", path, repoPath)
+			}
+			return exec.Command("true")
+		}
+		// Mock cloneCommand so it's not called if repo already exists
+		cloneCommand = func(owner, repoName, path string) *exec.Cmd {
+			t.Fatalf("cloneCommand should not be called if repo exists")
+			return exec.Command("false") // Should not be reached
+		}
+
+		rc := &RepoCache{
+			Owner:    "testowner",
+			RepoName: "testrepo",
+			Path:     repoPath,
+		}
+
+		if err := rc.Update(); err != nil {
+			t.Errorf("Update() failed unexpectedly: %v", err)
+		}
+		if !syncCalled {
+			t.Error("ghSyncCommand was not called")
+		}
+	})
+
+	t.Run("clones and then updates if repository does not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repoPath := filepath.Join(tmpDir, "gh-qpr-repo-uncloned")
+
+		var cloneCalled bool
+		var syncCalled bool
+
+		// Mock cloneCommand to succeed and mark as called
+		cloneCommand = func(owner, repoName, path string) *exec.Cmd {
+			cloneCalled = true
+			return exec.Command("true")
+		}
+		// Mock ghSyncCommand to succeed and mark as called
+		ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
+			syncCalled = true
+			return exec.Command("true")
+		}
+
+		rc := &RepoCache{
+			Owner:    "testowner",
+			RepoName: "testrepo",
+			Path:     repoPath,
+		}
+
+		if err := rc.Update(); err != nil {
+			t.Fatalf("Update() failed unexpectedly: %v", err)
+		}
+
+		if !cloneCalled {
+			t.Error("cloneCommand was not called when repository did not exist")
+		}
+		if !syncCalled {
+			t.Error("ghSyncCommand was not called after cloning")
+		}
+	})
+
+	t.Run("returns error if gh repo sync fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repoPath := filepath.Join(tmpDir, "gh-qpr-repo-sync-fail")
+
+		// Simulate an already cloned repository
+		if err := os.MkdirAll(repoPath, 0755); err != nil {
+			t.Fatalf("failed to create test repo directory: %v", err)
+		}
+
+		var syncCalled bool // Track if ghSyncCommand was called
+
+		// Mock gh repo sync to fail
+		ghSyncCommand = func(owner, repoName, path string) *exec.Cmd {
+			syncCalled = true
+			return exec.Command("false") // `false` command exits with non-zero status
+		}
+		cloneCommand = func(owner, repoName, path string) *exec.Cmd {
+			return exec.Command("true") // Ensure cloned always works
+		}
+
+		rc := &RepoCache{
+			Owner:    "testowner",
+			RepoName: "testrepo",
+			Path:     repoPath,
+		}
+
+		err := rc.Update()
+		if err == nil {
+			t.Error("Update() did not return an error when gh repo sync failed")
+		}
+		if err != nil && !strings.Contains(err.Error(), "failed to update repository") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+		if !syncCalled {
+			t.Error("ghSyncCommand was not called")
 		}
 	})
 }

--- a/main.go
+++ b/main.go
@@ -55,47 +55,111 @@ func runTemplatePR(action string) func(cmd *cobra.Command, args []string) error 
 		err = cmdExec.Run()
 
 		if err != nil {
+
 			stderrOutput := stderrBuf.String()
+
 			if strings.Contains(stderrOutput, "GraphQL: Projects (classic) is being deprecated") {
+
 				return fmt.Errorf(
+
 					"error running gh pr %s: The `gh` CLI encountered a deprecated GitHub Projects API. "+
+
 						"This is likely due to an outdated `gh` CLI version. "+
+
 						"Please update your GitHub CLI to the latest version. "+
+
 						"Original error: %v", action, err)
+
 			}
+
 			return fmt.Errorf("error running gh pr %s: %w", action, err)
+
 		}
+
 		return nil
+
 	}
+
+}
+
+func runUpdateRepo(cmd *cobra.Command, args []string) error {
+
+	repoOwner, repoName := lib.GetRepoFromEnv()
+
+	repoCache, err := lib.NewRepoCache(repoOwner, repoName)
+
+	if err != nil {
+
+		return fmt.Errorf("error creating repo cache: %v", err)
+
+	}
+
+	if err := repoCache.Update(); err != nil {
+
+		return fmt.Errorf("error updating repository cache: %v", err)
+
+	}
+
+	fmt.Println("Repository cache updated successfully.")
+
+	return nil
+
 }
 
 func main() {
+
 	var rootCmd = &cobra.Command{
-		Use:   "gh-qpr",
+
+		Use: "gh-qpr",
+
 		Short: "GitHub PR helper for templates",
 	}
 
 	createCmd := &cobra.Command{
-		Use:   "create",
+
+		Use: "create",
+
 		Short: "Create a new pull request using a template",
-		RunE:  runTemplatePR("create"),
+
+		RunE: runTemplatePR("create"),
 	}
+
 	createCmd.Flags().StringP("template", "t", "", "template file name (required)")
+
 	createCmd.Flags().StringP("title", "T", "", "pull request title (default: QPR)")
+
 	createCmd.MarkFlagRequired("template")
 
 	editCmd := &cobra.Command{
-		Use:   "edit",
+
+		Use: "edit",
+
 		Short: "Edit an existing pull request using a template.  WARNING: Overwrites existing description.",
-		RunE:  runTemplatePR("edit"),
+
+		RunE: runTemplatePR("edit"),
 	}
+
 	editCmd.Flags().StringP("template", "t", "", "template file name (required)")
+
 	editCmd.MarkFlagRequired("template")
 
-	rootCmd.AddCommand(createCmd, editCmd)
+	updateCmd := &cobra.Command{
+
+		Use: "update",
+
+		Short: "Update the local repository cache with the latest changes from remote.",
+
+		RunE: runUpdateRepo,
+	}
+
+	rootCmd.AddCommand(createCmd, editCmd, updateCmd)
 
 	if err := rootCmd.Execute(); err != nil {
+
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+
 		os.Exit(1)
+
 	}
+
 }


### PR DESCRIPTION

# Goal
_Explain the high-level goal of this PR. What problem does it solve, or what functionality does it add?_

Allow updating the template repo.  

# Summary
Adds a gh-qpr update command that pulls the latest changes from the remote template repository into the local  cache. This is useful when templates have been updated and users need to sync without re-cloning.


# Testing
_Is this change tested within this Pull Request?  Was test coverage added? Does the change require post-change verifiction instead?_

Test cases were added.  The extension was reinstalled locally prior to merge and tested manually.

```
gh qpr update
Updating karldreher/gh-qpr in /Users/karl/.gh-qpr/gh-qpr...
✓ Synced the "main" branch from "karldreher/gh-qpr" to local repository
Repository cache updated successfully.
```
