### PR TITLE
feat: allow selecting a default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,24 @@ This tool provides an interface, which:
 
 
 # Usage
+Example: Set a default template
+
+`gh qpr default`
+
+- Interactively select a default template from those available in your configured repo.
+- The selection is saved to `~/.gh-qpr/config.json` and used automatically by `create` and `edit`.
+
 Example: Create a Quality Pull Request
 
 `gh qpr create --template reviewer-first.md`
 
-- Template is always required.  
 - In the example above, the `reviewer-first.md` template is selected, from the [`reviewer-first.md`](templates/reviewer-first.md) file in this repository.  (the default repository)
 - `.md` extensions are optional in template selection.
+- `--template` is optional if a default has been set via `gh qpr default` or `GH_QPR_DEFAULT_TEMPLATE`.
+
+Example: Create without specifying a template (uses default)
+
+`gh qpr create`
 
 Example: Customize Title
 `gh qpr create --template reviewer-first --title "feat: new api endpoint`
@@ -53,4 +64,10 @@ Example: Get Help
 # Usage (Advanced)
 ## Bring Your Own Repo
 Set the environment variable `GH_QPR_REPO` in the format `owner/repo`.  This repo will be the place where *all* templates are gathered.  Place them in a directory called `templates` in this repo.
+
+## Default Template
+The default template is resolved in this order:
+1. `--template` flag (explicit, always wins)
+2. `GH_QPR_DEFAULT_TEMPLATE` environment variable
+3. Value saved by `gh qpr default` (stored in `~/.gh-qpr/config.json`)
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -8,7 +8,11 @@ import (
 )
 
 // Config holds user-level persistent settings for gh-qpr.
+// It is persisted as JSON at ~/.gh-qpr/config.json.
 type Config struct {
+	// DefaultTemplate is the name of the template to use when --template is not provided.
+	// Set via `gh qpr default` or the GH_QPR_DEFAULT_TEMPLATE environment variable.
+	// The value should match a template name in the configured repo (with or without .md extension).
 	DefaultTemplate string `json:"default_template"`
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Config holds user-level persistent settings for gh-qpr.
+type Config struct {
+	DefaultTemplate string `json:"default_template"`
+}
+
+// ConfigPath returns the absolute path to the config file (~/.gh-qpr/config.json).
+func ConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	return filepath.Join(home, ".gh-qpr", "config.json"), nil
+}
+
+// LoadConfig reads the config file and returns the parsed Config.
+// If the file does not exist, it returns a zero-value Config and no error.
+func LoadConfig() (Config, error) {
+	path, err := ConfigPath()
+	if err != nil {
+		return Config{}, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return Config{}, nil
+	}
+	if err != nil {
+		return Config{}, fmt.Errorf("reading config file: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parsing config file: %w", err)
+	}
+	return cfg, nil
+}
+
+// SaveConfig writes cfg to the config file, creating the directory if needed.
+func SaveConfig(cfg Config) error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding config: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+	return nil
+}

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -76,6 +76,28 @@ func TestLoadConfig_MalformedJSON(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_WrongFieldType(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".gh-qpr")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// default_template must be a string; passing a number violates the schema.
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"default_template": 123}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Error("LoadConfig() expected error for wrong field type, got nil")
+	}
+	if !strings.Contains(err.Error(), "parsing config file") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestSaveConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -1,0 +1,114 @@
+package lib
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	path, err := ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath() failed: %v", err)
+	}
+	if !strings.HasSuffix(path, filepath.Join(".gh-qpr", "config.json")) {
+		t.Errorf("unexpected config path: %s", path)
+	}
+	if !strings.HasPrefix(path, tmpDir) {
+		t.Errorf("config path %s is not under HOME %s", path, tmpDir)
+	}
+}
+
+func TestLoadConfig_FileNotExist(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() returned error for missing file: %v", err)
+	}
+	if cfg.DefaultTemplate != "" {
+		t.Errorf("expected empty DefaultTemplate, got %q", cfg.DefaultTemplate)
+	}
+}
+
+func TestLoadConfig_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".gh-qpr")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(Config{DefaultTemplate: "simple"})
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() failed: %v", err)
+	}
+	if cfg.DefaultTemplate != "simple" {
+		t.Errorf("expected DefaultTemplate %q, got %q", "simple", cfg.DefaultTemplate)
+	}
+}
+
+func TestLoadConfig_MalformedJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".gh-qpr")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{bad json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Error("LoadConfig() expected error for malformed JSON, got nil")
+	}
+}
+
+func TestSaveConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg := Config{DefaultTemplate: "reviewer-first"}
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig() failed: %v", err)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() after SaveConfig() failed: %v", err)
+	}
+	if loaded.DefaultTemplate != cfg.DefaultTemplate {
+		t.Errorf("round-trip mismatch: got %q, want %q", loaded.DefaultTemplate, cfg.DefaultTemplate)
+	}
+}
+
+func TestSaveConfig_CreatesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Confirm ~/.gh-qpr does not exist yet
+	configDir := filepath.Join(tmpDir, ".gh-qpr")
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Fatal("config directory should not exist before SaveConfig")
+	}
+
+	if err := SaveConfig(Config{DefaultTemplate: "simple"}); err != nil {
+		t.Fatalf("SaveConfig() failed: %v", err)
+	}
+
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		t.Error("SaveConfig() did not create the config directory")
+	}
+}

--- a/lib/repo.go
+++ b/lib/repo.go
@@ -108,6 +108,9 @@ func (rc *RepoCache) ListTemplates() ([]string, error) {
 	return names, nil
 }
 
+// GetRepoFromEnv returns the template repository owner and name.
+// It reads GH_QPR_REPO (format: "owner/repo") and falls back to "karldreher/gh-qpr".
+// Exits with a non-zero status if GH_QPR_REPO is set but malformed.
 func GetRepoFromEnv() (string, string) {
 	repoEnv := os.Getenv("GH_QPR_REPO")
 	if repoEnv == "" {

--- a/lib/repo.go
+++ b/lib/repo.go
@@ -83,6 +83,31 @@ func (rc *RepoCache) TemplatePath(templateName string) string {
 	return templatePath
 }
 
+// ListTemplates returns the base names (without .md extension) of all *.md files
+// in the templates subdirectory of the cache.
+// Returns nil, nil if the directory does not exist.
+func (rc *RepoCache) ListTemplates() ([]string, error) {
+	dir := filepath.Join(rc.Path, "templates")
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading templates directory: %w", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if filepath.Ext(name) == ".md" {
+			names = append(names, strings.TrimSuffix(name, ".md"))
+		}
+	}
+	return names, nil
+}
+
 func GetRepoFromEnv() (string, string) {
 	repoEnv := os.Getenv("GH_QPR_REPO")
 	if repoEnv == "" {

--- a/lib/repo_test.go
+++ b/lib/repo_test.go
@@ -107,6 +107,65 @@ func TestEnsureCloned(t *testing.T) {
 	})
 }
 
+func TestListTemplates(t *testing.T) {
+	t.Run("returns nil for missing templates dir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		rc := &RepoCache{Path: tmpDir}
+		names, err := rc.ListTemplates()
+		if err != nil {
+			t.Fatalf("ListTemplates() unexpected error: %v", err)
+		}
+		if len(names) != 0 {
+			t.Errorf("expected empty slice, got %v", names)
+		}
+	})
+
+	t.Run("returns template names without extension", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		templatesDir := filepath.Join(tmpDir, "templates")
+		if err := os.MkdirAll(templatesDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		for _, name := range []string{"alpha.md", "beta.md", "notes.txt"} {
+			if err := os.WriteFile(filepath.Join(templatesDir, name), []byte(""), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		rc := &RepoCache{Path: tmpDir}
+		names, err := rc.ListTemplates()
+		if err != nil {
+			t.Fatalf("ListTemplates() unexpected error: %v", err)
+		}
+		if len(names) != 2 {
+			t.Fatalf("expected 2 templates, got %d: %v", len(names), names)
+		}
+		if names[0] != "alpha" || names[1] != "beta" {
+			t.Errorf("unexpected template names: %v", names)
+		}
+	})
+
+	t.Run("skips subdirectories", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		templatesDir := filepath.Join(tmpDir, "templates")
+		if err := os.MkdirAll(filepath.Join(templatesDir, "subdir"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(templatesDir, "foo.md"), []byte(""), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		rc := &RepoCache{Path: tmpDir}
+		names, err := rc.ListTemplates()
+		if err != nil {
+			t.Fatalf("ListTemplates() unexpected error: %v", err)
+		}
+		if len(names) != 1 || names[0] != "foo" {
+			t.Errorf("expected [foo], got %v", names)
+		}
+	})
+}
+
 func TestUpdate(t *testing.T) {
 	oldSyncCommand := syncCommand
 	oldCloneCommand := cloneCommand

--- a/main.go
+++ b/main.go
@@ -32,6 +32,9 @@ func resolveTemplate(flagValue string) (string, error) {
 	return "", fmt.Errorf("no template specified: use --template, set GH_QPR_DEFAULT_TEMPLATE, or run 'gh qpr default'")
 }
 
+// runDefaultCmd is the handler for `gh qpr default`. It lists available templates
+// from the local cache and prompts the user to select one, then persists the
+// choice to ~/.gh-qpr/config.json.
 func runDefaultCmd(cmd *cobra.Command, args []string) error {
 	repoOwner, repoName := lib.GetRepoFromEnv()
 	repoCache, err := lib.NewRepoCache(repoOwner, repoName)
@@ -72,6 +75,9 @@ func runDefaultCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// runTemplatePR returns a Cobra RunE handler for the given PR action ("create" or "edit").
+// It resolves the template via resolveTemplate, reads the template body from the local
+// cache, and invokes `gh pr <action>` with that body.
 func runTemplatePR(action string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		templateFlagValue, _ := cmd.Flags().GetString("template")
@@ -144,6 +150,8 @@ func runTemplatePR(action string) func(cmd *cobra.Command, args []string) error 
 
 }
 
+// runUpdateRepo is the handler for `gh qpr update`. It syncs the local template
+// repo cache with the latest changes from the remote.
 func runUpdateRepo(cmd *cobra.Command, args []string) error {
 
 	repoOwner, repoName := lib.GetRepoFromEnv()

--- a/main.go
+++ b/main.go
@@ -1,21 +1,83 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/karldreher/gh-qpr/lib"
 	"github.com/spf13/cobra"
 )
 
+// resolveTemplate determines the effective template name, checking (in order):
+// the explicit flag value, GH_QPR_DEFAULT_TEMPLATE env var, and the config file.
+func resolveTemplate(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if v := os.Getenv("GH_QPR_DEFAULT_TEMPLATE"); v != "" {
+		return v, nil
+	}
+	cfg, err := lib.LoadConfig()
+	if err != nil {
+		return "", fmt.Errorf("loading config: %w", err)
+	}
+	if cfg.DefaultTemplate != "" {
+		return cfg.DefaultTemplate, nil
+	}
+	return "", fmt.Errorf("no template specified: use --template, set GH_QPR_DEFAULT_TEMPLATE, or run 'gh qpr default'")
+}
+
+func runDefaultCmd(cmd *cobra.Command, args []string) error {
+	repoOwner, repoName := lib.GetRepoFromEnv()
+	repoCache, err := lib.NewRepoCache(repoOwner, repoName)
+	if err != nil {
+		return fmt.Errorf("error creating repo cache: %v", err)
+	}
+	if err := repoCache.EnsureCloned(); err != nil {
+		return fmt.Errorf("error cloning repository: %v", err)
+	}
+	templates, err := repoCache.ListTemplates()
+	if err != nil {
+		return fmt.Errorf("error listing templates: %v", err)
+	}
+	if len(templates) == 0 {
+		return fmt.Errorf("no templates found in %s", repoCache.Path)
+	}
+	fmt.Println("Available templates:")
+	for i, name := range templates {
+		fmt.Printf("  %d) %s\n", i+1, name)
+	}
+	fmt.Printf("Select template [1-%d]: ", len(templates))
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	idx, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil || idx < 1 || idx > len(templates) {
+		return fmt.Errorf("invalid selection: %q", strings.TrimSpace(line))
+	}
+	chosen := templates[idx-1]
+	cfg, err := lib.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading config: %v", err)
+	}
+	cfg.DefaultTemplate = chosen
+	if err := lib.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("error saving config: %v", err)
+	}
+	fmt.Printf("Default template set to: %s\n", chosen)
+	return nil
+}
+
 func runTemplatePR(action string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		templateName, _ := cmd.Flags().GetString("template")
-		if templateName == "" {
-			return fmt.Errorf("--template flag is required")
+		templateFlagValue, _ := cmd.Flags().GetString("template")
+		templateName, err := resolveTemplate(templateFlagValue)
+		if err != nil {
+			return err
 		}
 
 		repoOwner, repoName := lib.GetRepoFromEnv()
@@ -124,11 +186,9 @@ func main() {
 		RunE: runTemplatePR("create"),
 	}
 
-	createCmd.Flags().StringP("template", "t", "", "template file name (required)")
+	createCmd.Flags().StringP("template", "t", "", "template file name (uses default if not set)")
 
 	createCmd.Flags().StringP("title", "T", "", "pull request title (default: QPR)")
-
-	createCmd.MarkFlagRequired("template")
 
 	editCmd := &cobra.Command{
 
@@ -139,9 +199,7 @@ func main() {
 		RunE: runTemplatePR("edit"),
 	}
 
-	editCmd.Flags().StringP("template", "t", "", "template file name (required)")
-
-	editCmd.MarkFlagRequired("template")
+	editCmd.Flags().StringP("template", "t", "", "template file name (uses default if not set)")
 
 	updateCmd := &cobra.Command{
 
@@ -152,7 +210,16 @@ func main() {
 		RunE: runUpdateRepo,
 	}
 
-	rootCmd.AddCommand(createCmd, editCmd, updateCmd)
+	defaultCmd := &cobra.Command{
+
+		Use:   "default",
+
+		Short: "Interactively select the default PR template",
+
+		RunE: runDefaultCmd,
+	}
+
+	rootCmd.AddCommand(createCmd, editCmd, updateCmd, defaultCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -118,7 +119,7 @@ func runTemplatePR(action string) func(cmd *cobra.Command, args []string) error 
 		cmdExec.Stdout = os.Stdout
 
 		var stderrBuf bytes.Buffer
-		cmdExec.Stderr = &stderrBuf
+		cmdExec.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 
 		err = cmdExec.Run()
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/karldreher/gh-qpr/lib"
+)
+
+func writeConfig(t *testing.T, home string, cfg lib.Config) {
+	t.Helper()
+	dir := filepath.Join(home, ".gh-qpr")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveTemplate_FlagTakesPriority(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("GH_QPR_DEFAULT_TEMPLATE", "from-env")
+	writeConfig(t, tmpDir, lib.Config{DefaultTemplate: "from-config"})
+
+	got, err := resolveTemplate("explicit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "explicit" {
+		t.Errorf("expected %q, got %q", "explicit", got)
+	}
+}
+
+func TestResolveTemplate_EnvVarOverridesConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("GH_QPR_DEFAULT_TEMPLATE", "from-env")
+	writeConfig(t, tmpDir, lib.Config{DefaultTemplate: "from-config"})
+
+	got, err := resolveTemplate("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "from-env" {
+		t.Errorf("expected %q, got %q", "from-env", got)
+	}
+}
+
+func TestResolveTemplate_ConfigFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("GH_QPR_DEFAULT_TEMPLATE", "")
+	writeConfig(t, tmpDir, lib.Config{DefaultTemplate: "from-config"})
+
+	got, err := resolveTemplate("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "from-config" {
+		t.Errorf("expected %q, got %q", "from-config", got)
+	}
+}
+
+func TestResolveTemplate_NoneSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("GH_QPR_DEFAULT_TEMPLATE", "")
+
+	_, err := resolveTemplate("")
+	if err == nil {
+		t.Fatal("expected error when no template is set, got nil")
+	}
+	if !strings.Contains(err.Error(), "no template specified") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}


### PR DESCRIPTION
# Goal
Make `--template` optional on `gh qpr create` and `gh qpr edit` by allowing users to configure a persistent default template. Users can set a default interactively via `gh qpr default`, via the `GH_QPR_DEFAULT_TEMPLATE` environment variable, or rely on the persisted config for day-to-day use without repeating the flag.

# Summary

- Adds `gh qpr default` subcommand — numbered list of available templates from the local cache, saves selection to `~/.gh-qpr/config.json`
- Adds `lib/config.go` with `Config` struct, `ConfigPath`, `LoadConfig`, and `SaveConfig` — no new dependencies, stdlib only
- Adds `RepoCache.ListTemplates()` to enumerate `*.md` files from the cache templates directory
- Template resolution order: `--template` flag > `GH_QPR_DEFAULT_TEMPLATE` env var > config file
- Fixes `gh pr create/edit` stderr being silently swallowed; now streams to terminal while still allowing specific error detection
- Adds godoc to all exported and handler functions; updates README with usage and resolution order docs

# Testing
Test coverage was added for all new logic:
- `lib/config_test.go`: `TestConfigPath`, `TestLoadConfig_FileNotExist`, `TestLoadConfig_Valid`, `TestLoadConfig_MalformedJSON`, `TestLoadConfig_WrongFieldType`, `TestSaveConfig`, `TestSaveConfig_CreatesDirectory`
- `lib/repo_test.go`: `TestListTemplates` (missing dir, .md filtering, subdirectory skipping)
- `main_test.go`: `TestResolveTemplate_*` covering all four priority cases

# What did you learn?
Capturing subprocess stderr for pattern matching (the existing GraphQL detection) silently drops error output for all other failure modes — `io.MultiWriter` is the clean fix to get both streaming and inspection without choosing one or the other.