### PR TITLE
feat: add list and view subcommands

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,47 @@ func runTemplatePR(action string) func(cmd *cobra.Command, args []string) error 
 
 }
 
+// runListCmd is the handler for `gh qpr list`. It prints the names of all
+// available templates in the local cache.
+func runListCmd(cmd *cobra.Command, args []string) error {
+	repoOwner, repoName := lib.GetRepoFromEnv()
+	repoCache, err := lib.NewRepoCache(repoOwner, repoName)
+	if err != nil {
+		return fmt.Errorf("error creating repo cache: %v", err)
+	}
+	if err := repoCache.EnsureCloned(); err != nil {
+		return fmt.Errorf("error cloning repository: %v", err)
+	}
+	templates, err := repoCache.ListTemplates()
+	if err != nil {
+		return fmt.Errorf("error listing templates: %v", err)
+	}
+	for _, name := range templates {
+		fmt.Println(name)
+	}
+	return nil
+}
+
+// runViewCmd is the handler for `gh qpr view <template>`. It prints the content
+// of the named template from the local cache.
+func runViewCmd(cmd *cobra.Command, args []string) error {
+	repoOwner, repoName := lib.GetRepoFromEnv()
+	repoCache, err := lib.NewRepoCache(repoOwner, repoName)
+	if err != nil {
+		return fmt.Errorf("error creating repo cache: %v", err)
+	}
+	if err := repoCache.EnsureCloned(); err != nil {
+		return fmt.Errorf("error cloning repository: %v", err)
+	}
+	templatePath := repoCache.TemplatePath(args[0])
+	content, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("template %q not found: %v", args[0], err)
+	}
+	fmt.Print(string(content))
+	return nil
+}
+
 // runUpdateRepo is the handler for `gh qpr update`. It syncs the local template
 // repo cache with the latest changes from the remote.
 func runUpdateRepo(cmd *cobra.Command, args []string) error {
@@ -228,7 +269,20 @@ func main() {
 		RunE: runDefaultCmd,
 	}
 
-	rootCmd.AddCommand(createCmd, editCmd, updateCmd, defaultCmd)
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List available PR templates",
+		RunE:  runListCmd,
+	}
+
+	viewCmd := &cobra.Command{
+		Use:   "view <template>",
+		Short: "View the content of a PR template",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runViewCmd,
+	}
+
+	rootCmd.AddCommand(createCmd, editCmd, updateCmd, defaultCmd, listCmd, viewCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,6 +66,124 @@ func TestResolveTemplate_ConfigFallback(t *testing.T) {
 	}
 	if got != "from-config" {
 		t.Errorf("expected %q, got %q", "from-config", got)
+	}
+}
+
+// setupFakeRepo creates a fake template repo cache under HOME and returns the
+// templates directory path. It sets HOME and GH_QPR_REPO via t.Setenv.
+func setupFakeRepo(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("GH_QPR_REPO", "testowner/testrepo")
+	templatesDir := filepath.Join(tmpDir, ".gh-qpr", "testrepo", "templates")
+	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	return templatesDir
+}
+
+// captureStdout redirects os.Stdout, calls f, then returns what was written.
+// os.Stdout is restored via defer so teardown is guaranteed even on panic.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+	f()
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestRunListCmd_PrintsTemplateNames(t *testing.T) {
+	templatesDir := setupFakeRepo(t)
+	for _, name := range []string{"alpha.md", "beta.md"} {
+		if err := os.WriteFile(filepath.Join(templatesDir, name), []byte(""), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	output := captureStdout(t, func() {
+		if err := runListCmd(nil, nil); err != nil {
+			t.Fatalf("runListCmd() error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "alpha") {
+		t.Errorf("expected output to contain %q, got: %q", "alpha", output)
+	}
+	if !strings.Contains(output, "beta") {
+		t.Errorf("expected output to contain %q, got: %q", "beta", output)
+	}
+}
+
+func TestRunListCmd_EmptyTemplatesDir(t *testing.T) {
+	setupFakeRepo(t) // creates empty templates dir
+
+	output := captureStdout(t, func() {
+		if err := runListCmd(nil, nil); err != nil {
+			t.Fatalf("runListCmd() error: %v", err)
+		}
+	})
+
+	if output != "" {
+		t.Errorf("expected no output for empty templates dir, got: %q", output)
+	}
+}
+
+func TestRunViewCmd_PrintsContent(t *testing.T) {
+	templatesDir := setupFakeRepo(t)
+	wantContent := "# Simple Template\n\nHello!"
+	if err := os.WriteFile(filepath.Join(templatesDir, "simple.md"), []byte(wantContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureStdout(t, func() {
+		if err := runViewCmd(nil, []string{"simple"}); err != nil {
+			t.Fatalf("runViewCmd() error: %v", err)
+		}
+	})
+
+	if output != wantContent {
+		t.Errorf("expected %q, got %q", wantContent, output)
+	}
+}
+
+func TestRunViewCmd_WithExtension(t *testing.T) {
+	templatesDir := setupFakeRepo(t)
+	wantContent := "# Reviewer First\n\nContent here."
+	if err := os.WriteFile(filepath.Join(templatesDir, "reviewer-first.md"), []byte(wantContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureStdout(t, func() {
+		if err := runViewCmd(nil, []string{"reviewer-first.md"}); err != nil {
+			t.Fatalf("runViewCmd() error: %v", err)
+		}
+	})
+
+	if output != wantContent {
+		t.Errorf("expected %q, got %q", wantContent, output)
+	}
+}
+
+func TestRunViewCmd_TemplateNotFound(t *testing.T) {
+	setupFakeRepo(t)
+
+	err := runViewCmd(nil, []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for missing template, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected error to contain 'not found', got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Goal

Add `gh qpr list` and `gh qpr view <template>` subcommands so users can browse and inspect available templates without entering the interactive `default` flow.

## Summary

- `gh qpr list` — prints available template names, one per line
- `gh qpr view <template>` — prints the full content of a named template (with or without `.md` extension)
- Both commands follow the existing `GetRepoFromEnv` / `NewRepoCache` / `EnsureCloned` pattern

## Testing

Tests added in `main_test.go` using two shared helpers:
- `setupFakeRepo` — wires `HOME` + `GH_QPR_REPO` via `t.Setenv` (auto-restored) and creates a fake templates dir under `t.TempDir()` (auto-cleaned)
- `captureStdout` — redirects `os.Stdout` via pipe with `defer`-based restore

Test cases: list prints names, list with empty dir, view prints content, view with `.md` extension, view for nonexistent template returns error.

## What did you learn?

Using `t.Setenv` for env var teardown and `defer` in stdout capture helpers keeps tests clean with no manual cleanup.